### PR TITLE
Add support for multiple S3 buckets and modularize bucket creation with nested stacks


### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,4 @@ CDK_DEPLOY_REGION=ap-southeast-1
 ENVIRONMENT=development
 
 OWNER=OpenWorkspace-o1
-S3_BUCKET_NAME=ow-aws-s3-bucket
+S3_BUCKET_NAMES=ow-aws-s3-bucket,ow-aws-s3-bucket-2

--- a/bin/aws-s3.ts
+++ b/bin/aws-s3.ts
@@ -21,7 +21,7 @@ checkEnvVariables('APP_NAME',
     'CDK_DEPLOY_REGION',
     'ENVIRONMENT',
     'OWNER',
-    'S3_BUCKET_NAME',
+    'S3_BUCKET_NAMES',
 );
 
 const { CDK_DEFAULT_ACCOUNT: account } = process.env;
@@ -52,11 +52,11 @@ const stackProps: AwsS3StackProps = {
     shortDeployEnvironment,
     appName,
     owner,
-    s3BucketName: process.env.S3_BUCKET_NAME!,
+    s3BucketNames: process.env.S3_BUCKET_NAMES!.split(','),
 };
 new AwsS3Stack(app, `AwsS3Stack`, {
     ...stackProps,
-    stackName: `${appName}-${deployEnvironment}-${cdkRegion}-AwsS3Stack`,
+    stackName: `${deployEnvironment}-${cdkRegion}-AwsS3Stack`,
     description: `AwsS3Stack for ${appName} in ${cdkRegion} ${deployEnvironment}.`,
 });
 

--- a/lib/AwsS3StackProps.ts
+++ b/lib/AwsS3StackProps.ts
@@ -2,8 +2,8 @@ import { StackProps } from "aws-cdk-lib";
 
 export interface AwsS3StackProps extends StackProps, AwsS3BaseStackProps {
     /**
-     * Name of the S3 bucket
-     * Example: "myapp-prod-bucket"
+     * Name of the S3 buckets
+     * Example: ["myapp-prod-bucket", "myapp-dev-bucket"]
      */
     readonly s3BucketNames: string[];
 }

--- a/lib/AwsS3StackProps.ts
+++ b/lib/AwsS3StackProps.ts
@@ -1,6 +1,14 @@
 import { StackProps } from "aws-cdk-lib";
 
-export interface AwsS3StackProps extends StackProps {
+export interface AwsS3StackProps extends StackProps, AwsS3BaseStackProps {
+    /**
+     * Name of the S3 bucket
+     * Example: "myapp-prod-bucket"
+     */
+    readonly s3BucketNames: string[];
+}
+
+export interface AwsS3BaseStackProps {
     /**
      * Prefix used for naming AWS resources
      * Example: "myapp-prod"
@@ -36,10 +44,4 @@ export interface AwsS3StackProps extends StackProps {
      * Example: "platform-team"
      */
     readonly owner: string;
-
-    /**
-     * Name of the S3 bucket
-     * Example: "myapp-prod-bucket"
-     */
-    readonly s3BucketName: string;
 }

--- a/lib/aws-s3-stack.ts
+++ b/lib/aws-s3-stack.ts
@@ -1,8 +1,8 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { AwsS3StackProps } from './AwsS3StackProps';
-import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as kms from 'aws-cdk-lib/aws-kms';
+import { AwsS3BucketsNestedStack } from './constructs/aws-s3-buckets-nested-stack';
 
 export class AwsS3Stack extends cdk.Stack {
   /**
@@ -17,82 +17,32 @@ export class AwsS3Stack extends cdk.Stack {
 
     const removalPolicy = props.deployEnvironment === 'production' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY;
 
-    const kmsKey = new kms.Key(this, `${props.resourcePrefix}-${props.s3BucketName}-kms-key`, {
+    const kmsKey = new kms.Key(this, `${props.resourcePrefix}-s3-buckets-kms-key`, {
       enableKeyRotation: true,
       removalPolicy: removalPolicy,
-      description: `${props.resourcePrefix}-${props.s3BucketName}-kms-key`,
+      description: `${props.resourcePrefix}-s3-buckets-kms-key`,
     });
 
-    // define an S3 bucket
-    const s3Bucket = new s3.Bucket(this, `${props.resourcePrefix}-${props.s3BucketName}`, {
-      bucketName: `${props.deployEnvironment}-${props.deployRegion}-${props.s3BucketName}`,
-      encryption: s3.BucketEncryption.S3_MANAGED,
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      publicReadAccess: false,
-      removalPolicy: removalPolicy,
-      autoDeleteObjects: removalPolicy === cdk.RemovalPolicy.DESTROY,
-      accessControl: s3.BucketAccessControl.BUCKET_OWNER_FULL_CONTROL,
-      versioned: true, // Enable versioning
-      lifecycleRules: [
-        {
-          transitions: [
-            {
-              storageClass: s3.StorageClass.INFREQUENT_ACCESS,
-              transitionAfter: cdk.Duration.days(90),
-            },
-            {
-              storageClass: s3.StorageClass.GLACIER,
-              transitionAfter: cdk.Duration.days(180),
-            },
-          ],
-        },
-      ],
-      intelligentTieringConfigurations: [
-        {
-          name: 'optimize-storage-costs',
-          archiveAccessTierTime: cdk.Duration.days(90),
-          deepArchiveAccessTierTime: cdk.Duration.days(180),
-        },
-      ],
-      serverAccessLogsBucket: new s3.Bucket(this, `${props.resourcePrefix}-s3-bucket-logs`, {
-        bucketName: `${props.deployEnvironment}-${props.deployRegion}-s3-bucket-logs`,
-        encryption: s3.BucketEncryption.KMS,
-        encryptionKey: kmsKey,
-        blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-        publicReadAccess: false,
+    for (const s3BucketName of props.s3BucketNames) {
+      new AwsS3BucketsNestedStack(this, `${props.resourcePrefix}-${s3BucketName}-nested-stack`, {
+        ...props,
+        s3BucketName,
+        kmsKeyArn: kmsKey.keyArn,
         removalPolicy: removalPolicy,
-        versioned: false,
-        enforceSSL: true,  // Ensure all requests to the S3 bucket use SSL
-      }),
-      enforceSSL: true,  // Ensure all requests to the S3 bucket use SSL
-      serverAccessLogsPrefix: `${props.resourcePrefix}-${props.deployRegion}-${props.s3BucketName}-logs/`
-    });
-
-    // export s3Bucket name
-    new cdk.CfnOutput(this, `${props.resourcePrefix}-${props.s3BucketName}-Export`, {
-      value: s3Bucket.bucketName,
-      exportName: `${props.deployEnvironment}-${props.deployRegion}-${props.s3BucketName}-Export`,
-      description: 'The name of the S3 bucket.',
-    });
-
-    // export s3Bucket ARN
-    new cdk.CfnOutput(this, `${props.resourcePrefix}-${props.s3BucketName}-Arn-Export`, {
-      value: s3Bucket.bucketArn,
-      exportName: `${props.deployEnvironment}-${props.deployRegion}-${props.s3BucketName}-Arn-Export`,
-      description: 'The ARN of the S3 bucket.',
-    });
+      });
+    }
 
     // export kmsKey ARN
-    new cdk.CfnOutput(this, `${props.resourcePrefix}-${props.s3BucketName}-kms-key-Arn-Export`, {
+    new cdk.CfnOutput(this, `${props.resourcePrefix}-s3-buckets-kms-key-Arn-Export`, {
       value: kmsKey.keyArn,
-      exportName: `${props.deployEnvironment}-${props.deployRegion}-${props.s3BucketName}-kms-key-Arn-Export`,
+      exportName: `${props.deployEnvironment}-${props.deployRegion}-s3-buckets-kms-key-Arn-Export`,
       description: 'The ARN of the KMS key.',
     });
 
     // export kmsKey ID
-    new cdk.CfnOutput(this, `${props.resourcePrefix}-${props.s3BucketName}-kms-key-Id-Export`, {
+    new cdk.CfnOutput(this, `${props.resourcePrefix}-s3-buckets-kms-key-Id-Export`, {
       value: kmsKey.keyId,
-      exportName: `${props.deployEnvironment}-${props.deployRegion}-${props.s3BucketName}-kms-key-Id-Export`,
+      exportName: `${props.deployEnvironment}-${props.deployRegion}-s3-buckets-kms-key-Id-Export`,
       description: 'The ID of the KMS key.',
     });
   }

--- a/lib/constructs/AwsS3BucketsNestedStackProps.ts
+++ b/lib/constructs/AwsS3BucketsNestedStackProps.ts
@@ -1,0 +1,9 @@
+import { NestedStackProps } from "aws-cdk-lib";
+import * as cdk from 'aws-cdk-lib';
+import { AwsS3BaseStackProps } from "../AwsS3StackProps";
+
+export interface AwsS3BucketsNestedStackProps extends NestedStackProps, AwsS3BaseStackProps {
+    readonly s3BucketName: string;
+    readonly kmsKeyArn: string;
+    readonly removalPolicy: cdk.RemovalPolicy;
+}

--- a/lib/constructs/aws-s3-buckets-nested-stack.ts
+++ b/lib/constructs/aws-s3-buckets-nested-stack.ts
@@ -1,0 +1,73 @@
+import { Construct } from "constructs";
+import { NestedStack } from "aws-cdk-lib";
+import { AwsS3BucketsNestedStackProps } from "./AwsS3BucketsNestedStackProps";
+import * as kms from 'aws-cdk-lib/aws-kms';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as cdk from 'aws-cdk-lib';
+
+export class AwsS3BucketsNestedStack extends NestedStack {
+  constructor(scope: Construct, id: string, props: AwsS3BucketsNestedStackProps) {
+    super(scope, id, props);
+
+    const existingKmsKey = kms.Key.fromKeyArn(this, `${props.resourcePrefix}-${props.s3BucketName}-kms-key`, props.kmsKeyArn);
+
+    // define an S3 bucket
+    const s3Bucket = new s3.Bucket(this, `${props.resourcePrefix}-${props.s3BucketName}`, {
+        bucketName: `${props.s3BucketName}`,
+        encryption: s3.BucketEncryption.S3_MANAGED,
+        blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+        publicReadAccess: false,
+        removalPolicy: props.removalPolicy,
+        autoDeleteObjects: props.removalPolicy === cdk.RemovalPolicy.DESTROY,
+        accessControl: s3.BucketAccessControl.BUCKET_OWNER_FULL_CONTROL,
+        versioned: true, // Enable versioning
+        lifecycleRules: [
+          {
+            transitions: [
+              {
+                storageClass: s3.StorageClass.INFREQUENT_ACCESS,
+                transitionAfter: cdk.Duration.days(90),
+              },
+              {
+                storageClass: s3.StorageClass.GLACIER,
+                transitionAfter: cdk.Duration.days(180),
+              },
+            ],
+          },
+        ],
+        intelligentTieringConfigurations: [
+          {
+            name: 'optimize-storage-costs',
+            archiveAccessTierTime: cdk.Duration.days(90),
+            deepArchiveAccessTierTime: cdk.Duration.days(180),
+          },
+        ],
+        serverAccessLogsBucket: new s3.Bucket(this, `${props.resourcePrefix}-s3-bucket-logs`, {
+          bucketName: `${props.deployEnvironment}-${props.deployRegion}-s3-bucket-logs`,
+          encryption: s3.BucketEncryption.KMS,
+          encryptionKey: existingKmsKey,
+          blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+          publicReadAccess: false,
+          removalPolicy: props.removalPolicy,
+          versioned: false,
+          enforceSSL: true,  // Ensure all requests to the S3 bucket use SSL
+        }),
+        enforceSSL: true,  // Ensure all requests to the S3 bucket use SSL
+        serverAccessLogsPrefix: `${props.resourcePrefix}-${props.deployRegion}-${props.s3BucketName}-logs/`
+    });
+
+    // export s3Bucket name
+    new cdk.CfnOutput(this, `${props.resourcePrefix}-${props.s3BucketName}-Export`, {
+    value: s3Bucket.bucketName,
+    exportName: `${props.deployEnvironment}-${props.deployRegion}-${props.s3BucketName}-Export`,
+    description: 'The name of the S3 bucket.',
+    });
+
+    // export s3Bucket ARN
+    new cdk.CfnOutput(this, `${props.resourcePrefix}-${props.s3BucketName}-Arn-Export`, {
+    value: s3Bucket.bucketArn,
+    exportName: `${props.deployEnvironment}-${props.deployRegion}-${props.s3BucketName}-Arn-Export`,
+    description: 'The ARN of the S3 bucket.',
+    });
+  }
+}

--- a/lib/constructs/aws-s3-buckets-nested-stack.ts
+++ b/lib/constructs/aws-s3-buckets-nested-stack.ts
@@ -24,50 +24,50 @@ export class AwsS3BucketsNestedStack extends NestedStack {
         lifecycleRules: [
           {
             transitions: [
-              {
-                storageClass: s3.StorageClass.INFREQUENT_ACCESS,
-                transitionAfter: cdk.Duration.days(90),
-              },
-              {
-                storageClass: s3.StorageClass.GLACIER,
-                transitionAfter: cdk.Duration.days(180),
-              },
+                {
+                    storageClass: s3.StorageClass.INFREQUENT_ACCESS,
+                    transitionAfter: cdk.Duration.days(90),
+                },
+                {
+                        storageClass: s3.StorageClass.GLACIER,
+                        transitionAfter: cdk.Duration.days(180),
+                },
             ],
           },
         ],
         intelligentTieringConfigurations: [
-          {
-            name: 'optimize-storage-costs',
-            archiveAccessTierTime: cdk.Duration.days(90),
-            deepArchiveAccessTierTime: cdk.Duration.days(180),
-          },
+            {
+                name: 'optimize-storage-costs',
+                archiveAccessTierTime: cdk.Duration.days(90),
+                deepArchiveAccessTierTime: cdk.Duration.days(180),
+            },
         ],
-        serverAccessLogsBucket: new s3.Bucket(this, `${props.resourcePrefix}-s3-bucket-logs`, {
-          bucketName: `${props.deployEnvironment}-${props.deployRegion}-s3-bucket-logs`,
-          encryption: s3.BucketEncryption.KMS,
-          encryptionKey: existingKmsKey,
-          blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-          publicReadAccess: false,
-          removalPolicy: props.removalPolicy,
-          versioned: false,
-          enforceSSL: true,  // Ensure all requests to the S3 bucket use SSL
+        serverAccessLogsBucket: new s3.Bucket(this, `${props.resourcePrefix}-${props.s3BucketName}-logs`, {
+            bucketName: `${props.s3BucketName}-logs`,
+            encryption: s3.BucketEncryption.KMS,
+            encryptionKey: existingKmsKey,
+            blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+            publicReadAccess: false,
+            removalPolicy: props.removalPolicy,
+            versioned: false,
+            enforceSSL: true,  // Ensure all requests to the S3 bucket use SSL
         }),
         enforceSSL: true,  // Ensure all requests to the S3 bucket use SSL
-        serverAccessLogsPrefix: `${props.resourcePrefix}-${props.deployRegion}-${props.s3BucketName}-logs/`
+        serverAccessLogsPrefix: `${props.resourcePrefix}-${props.s3BucketName}-logs/`
     });
 
     // export s3Bucket name
     new cdk.CfnOutput(this, `${props.resourcePrefix}-${props.s3BucketName}-Export`, {
-    value: s3Bucket.bucketName,
-    exportName: `${props.deployEnvironment}-${props.deployRegion}-${props.s3BucketName}-Export`,
-    description: 'The name of the S3 bucket.',
+        value: s3Bucket.bucketName,
+        exportName: `${props.deployEnvironment}-${props.deployRegion}-${props.s3BucketName}-Export`,
+        description: 'The name of the S3 bucket.',
     });
 
     // export s3Bucket ARN
     new cdk.CfnOutput(this, `${props.resourcePrefix}-${props.s3BucketName}-Arn-Export`, {
-    value: s3Bucket.bucketArn,
-    exportName: `${props.deployEnvironment}-${props.deployRegion}-${props.s3BucketName}-Arn-Export`,
-    description: 'The ARN of the S3 bucket.',
+        value: s3Bucket.bucketArn,
+        exportName: `${props.deployEnvironment}-${props.deployRegion}-${props.s3BucketName}-Arn-Export`,
+        description: 'The ARN of the S3 bucket.',
     });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aws-s3",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "2.173.2",
+        "aws-cdk-lib": "2.173.4",
         "cdk-nag": "^2.34.23",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7"
@@ -21,15 +21,15 @@
         "@types/jest": "^29.5.14",
         "@types/node": "22.10.2",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.173.2",
+        "aws-cdk": "2.173.4",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "typescript": "~5.7.2"
       },
       "peerDependencies": {
-        "aws-cdk": "2.173.2",
-        "aws-cdk-lib": "2.173.2",
+        "aws-cdk": "2.173.4",
+        "aws-cdk-lib": "2.173.4",
         "constructs": "^10.4.2"
       }
     },
@@ -1286,9 +1286,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.173.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.173.2.tgz",
-      "integrity": "sha512-qyMU4FoRJdZDUpsOBqyRBALBjf5A2N/MaHKX9iJUkbTET+d+nR07x3ai4TcEES+8pqPFHMTKpQMRDXs9Py/15w==",
+      "version": "2.173.4",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.173.4.tgz",
+      "integrity": "sha512-zgs3xU28VEKIwHwJHu0ZHeoEmwLGnHS2jPCMc2MsIMZu+a7CKyE77Tw6LwJkuuB96BQyqr6xJB3SbeWjXmcFhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1302,9 +1302,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.173.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.173.2.tgz",
-      "integrity": "sha512-cL9+z8Pl3VZGoO7BwdsrFAOeud/vSl3at7OvmhihbNprMN15XuFUx/rViAU5OI1m92NbV4NBzYSLbSeCwYLNyw==",
+      "version": "2.173.4",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.173.4.tgz",
+      "integrity": "sha512-0reN94TzkWmyVZDDBlYB4qzJUig8wTHEe82YLHlWRUhrU78fT+drVGUr+lYZwwETaZ+8fLdCOl9ULvFNq7iczQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",

--- a/package.json
+++ b/package.json
@@ -15,21 +15,21 @@
     "@types/jest": "^29.5.14",
     "@types/node": "22.10.2",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.173.2",
+    "aws-cdk": "2.173.4",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "~5.7.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.173.2",
+    "aws-cdk-lib": "2.173.4",
     "cdk-nag": "^2.34.23",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7"
   },
   "peerDependencies": {
-    "aws-cdk": "2.173.2",
-    "aws-cdk-lib": "2.173.2",
+    "aws-cdk": "2.173.4",
+    "aws-cdk-lib": "2.173.4",
     "constructs": "^10.4.2"
   }
 }

--- a/process-env.d.ts
+++ b/process-env.d.ts
@@ -5,6 +5,6 @@ declare module NodeJS {
         ENVIRONMENT: string;
         APP_NAME: string;
         OWNER: string;
-        S3_BUCKET_NAME: string;
+        S3_BUCKET_NAMES: string;
     }
 }


### PR DESCRIPTION
### **PR Type**
Feature, Enhancement, Dependencies

___

### **PR Description**
- Introduced support for multiple S3 buckets by replacing `S3_BUCKET_NAME` with `S3_BUCKET_NAMES` in environment variables and configuration.
- Added a new `AwsS3BucketsNestedStack` construct to handle the creation of individual S3 buckets, improving modularity and scalability.
- Updated `AwsS3Stack` to iterate over `s3BucketNames` and delegate bucket creation to `AwsS3BucketsNestedStack`.
- Refactored `AwsS3StackProps` to include `s3BucketNames` and moved shared properties to a new `AwsS3BaseStackProps` interface.
- Updated `.env.example` to reflect the new `S3_BUCKET_NAMES` format.
- Upgraded `aws-cdk` and `aws-cdk-lib` dependencies from version `2.173.2` to `2.173.4`.
- Updated JSDoc comments for better clarity and documentation.
