### PR TITLE
Improve naming and formatting for AwsS3BucketsNestedStack in AWS CDK


### DIFF
--- a/lib/aws-s3-stack.ts
+++ b/lib/aws-s3-stack.ts
@@ -24,11 +24,12 @@ export class AwsS3Stack extends cdk.Stack {
     });
 
     for (const s3BucketName of props.s3BucketNames) {
-      new AwsS3BucketsNestedStack(this, `${props.resourcePrefix}-${s3BucketName}-nested-stack`, {
+      new AwsS3BucketsNestedStack(this, `${s3BucketName}-AwsS3BucketsNestedStack`, {
         ...props,
         s3BucketName,
         kmsKeyArn: kmsKey.keyArn,
         removalPolicy: removalPolicy,
+        description: `${props.resourcePrefix}-${s3BucketName}-AwsS3BucketsNestedStack`,
       });
     }
 

--- a/lib/constructs/aws-s3-buckets-nested-stack.ts
+++ b/lib/constructs/aws-s3-buckets-nested-stack.ts
@@ -29,8 +29,8 @@ export class AwsS3BucketsNestedStack extends NestedStack {
                     transitionAfter: cdk.Duration.days(90),
                 },
                 {
-                        storageClass: s3.StorageClass.GLACIER,
-                        transitionAfter: cdk.Duration.days(180),
+                    storageClass: s3.StorageClass.GLACIER,
+                    transitionAfter: cdk.Duration.days(180),
                 },
             ],
           },


### PR DESCRIPTION
### **PR Type**
Enhancement, Formatting

___

### **PR Description**
- Updated the naming convention for `AwsS3BucketsNestedStack` instances to use a shorter and more descriptive format.
- Added a `description` property to `AwsS3BucketsNestedStack` instances for better clarity and documentation.
- Fixed indentation issues in the lifecycle configuration of `AwsS3BucketsNestedStack` to improve code readability.
