### PR TITLE
Enhance S3 bucket security with KMS encryption and key rotation


### DIFF
--- a/lib/aws-s3-stack.ts
+++ b/lib/aws-s3-stack.ts
@@ -18,7 +18,9 @@ export class AwsS3Stack extends cdk.Stack {
     const removalPolicy = props.deployEnvironment === 'production' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY;
 
     const kmsKey = new kms.Key(this, `${props.resourcePrefix}-s3-buckets-kms-key`, {
+      enabled: true,
       enableKeyRotation: true,
+      rotationPeriod: cdk.Duration.days(30),
       removalPolicy: removalPolicy,
       description: `${props.resourcePrefix}-s3-buckets-kms-key`,
     });

--- a/lib/constructs/aws-s3-buckets-nested-stack.ts
+++ b/lib/constructs/aws-s3-buckets-nested-stack.ts
@@ -14,7 +14,8 @@ export class AwsS3BucketsNestedStack extends NestedStack {
     // define an S3 bucket
     const s3Bucket = new s3.Bucket(this, `${props.resourcePrefix}-${props.s3BucketName}`, {
         bucketName: `${props.s3BucketName}`,
-        encryption: s3.BucketEncryption.S3_MANAGED,
+        encryption: s3.BucketEncryption.KMS,
+        encryptionKey: existingKmsKey,
         blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
         publicReadAccess: false,
         removalPolicy: props.removalPolicy,
@@ -44,8 +45,7 @@ export class AwsS3BucketsNestedStack extends NestedStack {
         ],
         serverAccessLogsBucket: new s3.Bucket(this, `${props.resourcePrefix}-${props.s3BucketName}-logs`, {
             bucketName: `${props.s3BucketName}-logs`,
-            encryption: s3.BucketEncryption.KMS,
-            encryptionKey: existingKmsKey,
+            encryption: s3.BucketEncryption.S3_MANAGED,
             blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
             publicReadAccess: false,
             removalPolicy: props.removalPolicy,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-s3",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-s3",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "aws-cdk-lib": "2.173.4",
         "cdk-nag": "^2.34.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-s3",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "bin": {
     "aws-s3": "bin/aws-s3.js"
   },


### PR DESCRIPTION
### **PR Type**
Enhancement, Security

___

### **PR Description**
- Enabled key rotation for the KMS key associated with S3 buckets and set the rotation period to 30 days.
- Updated S3 bucket encryption to use KMS encryption instead of S3-managed encryption for enhanced security.
- Reverted server access logs bucket encryption to use S3-managed encryption.
- Incremented the project version in `package.json` from `0.1.0` to `0.1.1`.
