### PR TITLE
Fix multiple buckets deployment issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [2025-03-01][PR#OpenWorkspace-o1/aws-s3-buckets/20](https://github.com/OpenWorkspace-o1/aws-s3-buckets/pull/20)
+
+### Fixed
+- Fixed multiple S3 bucket deployment issue by dynamically constructing bucket names using `resourcePrefix` and exporting deployment bucket names using `CfnOutput`.
+
+### Updated
+- Updated `aws-cdk` to `2.1001.0`, `aws-cdk-lib` to `2.181.1`, and `cdk-nag` to `2.35.34`.
+- Updated `@types/node` to `22.13.7` and `typescript` to `~5.8.2`.
+- Increased KMS key rotation period from `30` to `90` days.
+
 ## [2025-01-11][https://github.com/OpenWorkspace-o1/aws-s3-buckets/pull/18]
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [2025-03-01][PR#OpenWorkspace-o1/aws-s3-buckets/20](https://github.com/OpenWorkspace-o1/aws-s3-buckets/pull/20)
+## [2025-03-01][PR#20](https://github.com/OpenWorkspace-o1/aws-s3-buckets/pull/20)
 
 ### Fixed
 - Fixed multiple S3 bucket deployment issue by dynamically constructing bucket names using `resourcePrefix` and exporting deployment bucket names using `CfnOutput`.
@@ -8,7 +8,7 @@
 - Updated `@types/node` to `22.13.7` and `typescript` to `~5.8.2`.
 - Increased KMS key rotation period from `30` to `90` days.
 
-## [2025-01-11][https://github.com/OpenWorkspace-o1/aws-s3-buckets/pull/18]
+## [2025-01-11] [PR#18](https://github.com/OpenWorkspace-o1/aws-s3-buckets/pull/18)
 
 ### Updated
 - Updated `aws-cdk` and `aws-cdk-lib` dependencies from `2.174.1` to `2.175.1`

--- a/lib/aws-s3-stack.ts
+++ b/lib/aws-s3-stack.ts
@@ -20,18 +20,26 @@ export class AwsS3Stack extends cdk.Stack {
     const kmsKey = new kms.Key(this, `${props.resourcePrefix}-s3-buckets-kms-key`, {
       enabled: true,
       enableKeyRotation: true,
-      rotationPeriod: cdk.Duration.days(30),
+      rotationPeriod: cdk.Duration.days(90),
       removalPolicy: removalPolicy,
       description: `${props.resourcePrefix}-s3-buckets-kms-key`,
     });
 
     for (const s3BucketName of props.s3BucketNames) {
+      const deploymentBucketName = `${props.resourcePrefix}-${s3BucketName}`;
       new AwsS3BucketsNestedStack(this, `${s3BucketName}-AwsS3BucketsNestedStack`, {
         ...props,
-        s3BucketName,
+        s3BucketName: deploymentBucketName,
         kmsKeyArn: kmsKey.keyArn,
         removalPolicy: removalPolicy,
-        description: `${props.resourcePrefix}-${s3BucketName}-AwsS3BucketsNestedStack`,
+        description: `${props.resourcePrefix}-${deploymentBucketName}-AwsS3BucketsNestedStack`,
+      });
+
+      // export deployment bucket name
+      new cdk.CfnOutput(this, `${props.resourcePrefix}-${s3BucketName}-deployment-bucket-name-Export`, {
+        value: deploymentBucketName,
+        exportName: `${props.deployEnvironment}-${props.deployRegion}-${s3BucketName}-deployment-bucket-name-Export`,
+        description: 'The name of the deployment bucket.',
       });
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "aws-s3",
       "version": "0.1.3",
       "dependencies": {
-        "aws-cdk-lib": "2.175.1",
-        "cdk-nag": "^2.34.23",
+        "aws-cdk-lib": "2.181.1",
+        "cdk-nag": "^2.35.34",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7"
       },
@@ -19,17 +19,17 @@
       "devDependencies": {
         "@tsconfig/node22": "^22.0.0",
         "@types/jest": "^29.5.14",
-        "@types/node": "22.10.5",
+        "@types/node": "22.13.7",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.175.1",
+        "aws-cdk": "2.1001.0",
         "jest": "^29.7.0",
-        "ts-jest": "^29.2.5",
+        "ts-jest": "^29.2.6",
         "ts-node": "^10.9.2",
-        "typescript": "~5.7.3"
+        "typescript": "~5.8.2"
       },
       "peerDependencies": {
-        "aws-cdk": "2.175.1",
-        "aws-cdk-lib": "2.175.1",
+        "aws-cdk": "2.1001.0",
+        "aws-cdk-lib": "2.181.1",
         "constructs": "^10.4.2"
       }
     },
@@ -53,12 +53,6 @@
       "integrity": "sha512-D+Jzwpl+zlBGjJf7nuRcz6JFNwqDQ+IzwIq0VSC4LMRRvrkhGE/ZE+zab3EnjmVkipcQqtQe+PVKefgmxETbvA==",
       "license": "Apache-2.0"
     },
-    "node_modules/@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.3.tgz",
-      "integrity": "sha512-cDG1w3ieM6eOT9mTefRuTypk95+oyD7P5X/wRltwmYxU7nZc3+076YEVS6vrjDKr3ADYbfn0lDKpfB1FBtO9CQ==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
@@ -66,17 +60,17 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "39.1.38",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-39.1.38.tgz",
-      "integrity": "sha512-T5nc7+y3pmfXD/LNft1mA8E8Q6IdsE0mta5nC1FZu5sQd+LUo9xGd0BwdzJpR54cgTW/bNcIs5ARoc6kWoRJaA==",
+      "version": "39.2.20",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-39.2.20.tgz",
+      "integrity": "sha512-RI7S8jphGA8mak154ElnEJQPNTTV4PZmA7jgqnBBHQGyOPJIXxtACubNQ5m4YgjpkK3UJHsWT+/cOAfM/Au/Wg==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "^1.4.1",
-        "semver": "^7.6.3"
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.1"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
@@ -88,7 +82,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.6.3",
+      "version": "7.7.1",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -1136,9 +1130,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.10.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
-      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "version": "22.13.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.7.tgz",
+      "integrity": "sha512-oU2q+BsQldB9lYxHNp/5aZO+/Bs0Usa74Abo9mAKulz4ahQyXRHK6UVKYIN8KSC8HXwhWSi7b49JnX+txuac0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1286,9 +1280,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.175.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.175.1.tgz",
-      "integrity": "sha512-duvy0FtGAAYqJi/x0MjBfCp60ZlDYl0X5/GrADwMz4AfHQ8aTXCyaVsdJuCxz0ZMHSNaFRuCNkAlc2Xu43zQmQ==",
+      "version": "2.1001.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1001.0.tgz",
+      "integrity": "sha512-Wp6fKNXcxBm+f8U1GkLV4gEgqq1pu5uwyDCMBg7ZB/6CtP+PsD/mPhuKyMULNWucDvYN8oy70XLOkMnxa3NWFw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1302,9 +1296,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.175.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.175.1.tgz",
-      "integrity": "sha512-2OiZDUeuAA5nBrWKxQVT0CHrQmLLx7SIpUeqyKRLEdiYPFlj3nCd/0KcVpsy6hPKS+IZp7Qm1kghmGMsV6JGoA==",
+      "version": "2.181.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.181.1.tgz",
+      "integrity": "sha512-PDxYiqzet17tigJ8icjzoZIzmcdusQfKNnwpRzcGu5//n3YqlKf/vGEkQuU0xcgt4lBMX4Yjuqfsl8wYidCESw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1321,9 +1315,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.208",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.3",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^39.0.1",
+        "@aws-cdk/cloud-assembly-schema": "^39.2.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.2.0",
@@ -1447,12 +1440,22 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.0.3",
+      "version": "3.0.6",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "inBundle": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.2.0",
+      "version": "11.3.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1502,7 +1505,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1612,7 +1615,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.8.2",
+      "version": "6.9.0",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1894,9 +1897,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/cdk-nag": {
-      "version": "2.34.23",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.34.23.tgz",
-      "integrity": "sha512-TCvQy5uCk1QHek7UhbmFh4Uk2HveXyuQ6jfUC0ZfW5HgAMhv8+6lTY56Jq09/rm0csKDzWnMpGGAXjgLW6rg0A==",
+      "version": "2.35.34",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.35.34.tgz",
+      "integrity": "sha512-1C9x9J2NKKXaziWheEN+jiE25SxBZYCadm63eR5wiJ7HosgL5xmSZAe1Rrj+CopF9f5ihCeCWdsbcTfaDNLliQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.156.0",
@@ -3907,7 +3910,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4138,9 +4140,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.2.5",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.5.tgz",
-      "integrity": "sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==",
+      "version": "29.2.6",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.6.tgz",
+      "integrity": "sha512-yTNZVZqc8lSixm+QGVFcPe6+yj7+TWZwIesuOWvfcn4B9bz5x4NDzVCQQjOs7Hfouu36aEqfEbo9Qpo+gq8dDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4151,7 +4153,7 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.6.3",
+        "semver": "^7.7.1",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -4187,9 +4189,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4267,9 +4269,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -13,23 +13,23 @@
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",
     "@types/jest": "^29.5.14",
-    "@types/node": "22.10.5",
+    "@types/node": "22.13.7",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.175.1",
+    "aws-cdk": "2.1001.0",
     "jest": "^29.7.0",
-    "ts-jest": "^29.2.5",
+    "ts-jest": "^29.2.6",
     "ts-node": "^10.9.2",
-    "typescript": "~5.7.3"
+    "typescript": "~5.8.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.175.1",
-    "cdk-nag": "^2.34.23",
+    "aws-cdk-lib": "2.181.1",
+    "cdk-nag": "^2.35.34",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7"
   },
   "peerDependencies": {
-    "aws-cdk": "2.175.1",
-    "aws-cdk-lib": "2.175.1",
+    "aws-cdk": "2.1001.0",
+    "aws-cdk-lib": "2.181.1",
     "constructs": "^10.4.2"
   }
 }


### PR DESCRIPTION
### **PR Type**
Bug fix, Dependencies

___

### **PR Description**
- Fixed multiple S3 bucket deployment issue by:
  - Constructing deployment bucket names dynamically using `resourcePrefix`.
  - Exporting deployment bucket names using `CfnOutput`.

- Updated AWS CDK dependencies:
  - `aws-cdk` to `2.1001.0`.
  - `aws-cdk-lib` to `2.181.1`.
  - `cdk-nag` to `2.35.34`.

- Increased KMS key rotation period from `30` to `90` days.

- Updated `@types/node` to `22.13.7` and `typescript` to `~5.8.2`.
