### PR TITLE
v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2025-03-09][PR#23](https://github.com/OpenWorkspace-o1/aws-s3-buckets/pull/23)
+
+### Updated
+- Updated `aws-cdk` from `2.1001.0` to `2.1003.0` and `aws-cdk-lib` from `2.181.1` to `2.182.0`.
+- Updated `cdk-nag` from `2.35.34` to `2.35.40`.
+- Updated `@types/node` from `22.13.7` to `22.13.10`.
+- Bumped project version from `0.1.3` to `0.1.4`.
+
 ## [2025-03-01][PR#20](https://github.com/OpenWorkspace-o1/aws-s3-buckets/pull/20)
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-s3",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-s3",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "aws-cdk-lib": "2.182.0",
         "cdk-nag": "^2.35.40",
@@ -3913,6 +3913,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "aws-s3",
       "version": "0.1.3",
       "dependencies": {
-        "aws-cdk-lib": "2.181.1",
-        "cdk-nag": "^2.35.34",
+        "aws-cdk-lib": "2.182.0",
+        "cdk-nag": "^2.35.40",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7"
       },
@@ -19,17 +19,17 @@
       "devDependencies": {
         "@tsconfig/node22": "^22.0.0",
         "@types/jest": "^29.5.14",
-        "@types/node": "22.13.7",
+        "@types/node": "22.13.10",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.1001.0",
+        "aws-cdk": "2.1003.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.6",
         "ts-node": "^10.9.2",
         "typescript": "~5.8.2"
       },
       "peerDependencies": {
-        "aws-cdk": "2.1001.0",
-        "aws-cdk-lib": "2.181.1",
+        "aws-cdk": "2.1003.0",
+        "aws-cdk-lib": "2.182.0",
         "constructs": "^10.4.2"
       }
     },
@@ -60,9 +60,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "39.2.20",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-39.2.20.tgz",
-      "integrity": "sha512-RI7S8jphGA8mak154ElnEJQPNTTV4PZmA7jgqnBBHQGyOPJIXxtACubNQ5m4YgjpkK3UJHsWT+/cOAfM/Au/Wg==",
+      "version": "40.7.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-40.7.0.tgz",
+      "integrity": "sha512-00wVKn9pOOGXbeNwA4E8FUFt0zIB4PmSO7PvIiDWgpaFX3G/sWyy0A3s6bg/n2Yvkghu8r4a8ckm+mAzkAYmfA==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -71,6 +71,9 @@
       "dependencies": {
         "jsonschema": "~1.4.1",
         "semver": "^7.7.1"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
@@ -1130,9 +1133,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.13.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.7.tgz",
-      "integrity": "sha512-oU2q+BsQldB9lYxHNp/5aZO+/Bs0Usa74Abo9mAKulz4ahQyXRHK6UVKYIN8KSC8HXwhWSi7b49JnX+txuac0w==",
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1280,9 +1283,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1001.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1001.0.tgz",
-      "integrity": "sha512-Wp6fKNXcxBm+f8U1GkLV4gEgqq1pu5uwyDCMBg7ZB/6CtP+PsD/mPhuKyMULNWucDvYN8oy70XLOkMnxa3NWFw==",
+      "version": "2.1003.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1003.0.tgz",
+      "integrity": "sha512-FORPDGW8oUg4tXFlhX+lv/j+152LO9wwi3/CwNr1WY3c3HwJUtc0fZGb2B3+Fzy6NhLWGHJclUsJPEhjEt8Nhg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1296,9 +1299,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.181.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.181.1.tgz",
-      "integrity": "sha512-PDxYiqzet17tigJ8icjzoZIzmcdusQfKNnwpRzcGu5//n3YqlKf/vGEkQuU0xcgt4lBMX4Yjuqfsl8wYidCESw==",
+      "version": "2.182.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.182.0.tgz",
+      "integrity": "sha512-emymzTJiCpPz8oF++oiFvFuLH1QZjv6NRNQGn7VuDrEewZFTM4VpiVco5NrxH+KCWnXquDBPF5sQIUo6HY7jLg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1316,7 +1319,7 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.208",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^39.2.0",
+        "@aws-cdk/cloud-assembly-schema": "^40.6.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.2.0",
@@ -1897,9 +1900,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/cdk-nag": {
-      "version": "2.35.34",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.35.34.tgz",
-      "integrity": "sha512-1C9x9J2NKKXaziWheEN+jiE25SxBZYCadm63eR5wiJ7HosgL5xmSZAe1Rrj+CopF9f5ihCeCWdsbcTfaDNLliQ==",
+      "version": "2.35.40",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.35.40.tgz",
+      "integrity": "sha512-S2zo25FTYLNY7uHRFKT4Hlapf8kGuTe9b/MIIxY5PXV76ZeCjhii6AsaV2hhIPx983ckbvv8cnjINoJATpKmcA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.156.0",

--- a/package.json
+++ b/package.json
@@ -13,23 +13,23 @@
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",
     "@types/jest": "^29.5.14",
-    "@types/node": "22.13.7",
+    "@types/node": "22.13.10",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.1001.0",
+    "aws-cdk": "2.1003.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.6",
     "ts-node": "^10.9.2",
     "typescript": "~5.8.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.181.1",
-    "cdk-nag": "^2.35.34",
+    "aws-cdk-lib": "2.182.0",
+    "cdk-nag": "^2.35.40",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7"
   },
   "peerDependencies": {
-    "aws-cdk": "2.1001.0",
-    "aws-cdk-lib": "2.181.1",
+    "aws-cdk": "2.1003.0",
+    "aws-cdk-lib": "2.182.0",
     "constructs": "^10.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-s3",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "bin": {
     "aws-s3": "bin/aws-s3.js"
   },


### PR DESCRIPTION
### **PR Type**
Dependencies

___

### **PR Description**
- Updated `aws-cdk` and `aws-cdk-lib` to newer versions.
  - `aws-cdk` from `2.1001.0` to `2.1003.0`.
  - `aws-cdk-lib` from `2.181.1` to `2.182.0`.

- Updated `cdk-nag` from `2.35.34` to `2.35.40`.

- Updated `@types/node` from `22.13.7` to `22.13.10`.

- Bumped project version from `0.1.3` to `0.1.4`.
