### PR TITLE
Fix serverAccessLogsBucket name rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [2025-03-10][PR#25](https://github.com/OpenWorkspace-o1/aws-ow-s3-buckets/pull/25)
+
+### Fixed
+- Fixed `serverAccessLogsBucket` naming rule to include `resourcePrefix`.
+
+### Updated
+- Updated `cdk-nag` from `2.35.40` to `2.35.41`.
+- Bumped package version from `0.1.4` to `0.1.5`.
+
 ## [2025-03-09][PR#23](https://github.com/OpenWorkspace-o1/aws-s3-buckets/pull/23)
 
 ### Updated

--- a/lib/constructs/aws-s3-buckets-nested-stack.ts
+++ b/lib/constructs/aws-s3-buckets-nested-stack.ts
@@ -23,18 +23,18 @@ export class AwsS3BucketsNestedStack extends NestedStack {
         accessControl: s3.BucketAccessControl.BUCKET_OWNER_FULL_CONTROL,
         versioned: true, // Enable versioning
         lifecycleRules: [
-          {
-            transitions: [
-                {
-                    storageClass: s3.StorageClass.INFREQUENT_ACCESS,
-                    transitionAfter: cdk.Duration.days(90),
-                },
-                {
-                    storageClass: s3.StorageClass.GLACIER,
-                    transitionAfter: cdk.Duration.days(180),
-                },
-            ],
-          },
+            {
+                transitions: [
+                    {
+                        storageClass: s3.StorageClass.INFREQUENT_ACCESS,
+                        transitionAfter: cdk.Duration.days(90),
+                    },
+                    {
+                        storageClass: s3.StorageClass.GLACIER,
+                        transitionAfter: cdk.Duration.days(180),
+                    },
+                ],
+            },
         ],
         intelligentTieringConfigurations: [
             {
@@ -44,15 +44,15 @@ export class AwsS3BucketsNestedStack extends NestedStack {
             },
         ],
         serverAccessLogsBucket: new s3.Bucket(this, `${props.resourcePrefix}-${props.s3BucketName}-logs`, {
-            bucketName: `${props.s3BucketName}-logs`,
+            bucketName: `${props.resourcePrefix}-${props.s3BucketName}-logs`,
             encryption: s3.BucketEncryption.S3_MANAGED,
             blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
             publicReadAccess: false,
             removalPolicy: props.removalPolicy,
             versioned: false,
-            enforceSSL: true,  // Ensure all requests to the S3 bucket use SSL
+            enforceSSL: true,
         }),
-        enforceSSL: true,  // Ensure all requests to the S3 bucket use SSL
+        enforceSSL: true,
         serverAccessLogsPrefix: `${props.resourcePrefix}-${props.s3BucketName}-logs/`
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "aws-s3",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-s3",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "aws-cdk-lib": "2.182.0",
-        "cdk-nag": "^2.35.40",
+        "cdk-nag": "^2.35.41",
         "constructs": "^10.4.2",
         "dotenv": "^16.4.7"
       },
@@ -1900,9 +1900,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/cdk-nag": {
-      "version": "2.35.40",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.35.40.tgz",
-      "integrity": "sha512-S2zo25FTYLNY7uHRFKT4Hlapf8kGuTe9b/MIIxY5PXV76ZeCjhii6AsaV2hhIPx983ckbvv8cnjINoJATpKmcA==",
+      "version": "2.35.41",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.35.41.tgz",
+      "integrity": "sha512-n1jD+guKd7rM19tyoNIAfjqSRDDgFe/VE0UXio64IakjUI1Pl13gQSjxmAp/5XqRvcNqIxaWrC3ohswFKU1t+w==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "aws-cdk-lib": "^2.156.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-s3",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "bin": {
     "aws-s3": "bin/aws-s3.js"
   },
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "2.182.0",
-    "cdk-nag": "^2.35.40",
+    "cdk-nag": "^2.35.41",
     "constructs": "^10.4.2",
     "dotenv": "^16.4.7"
   },


### PR DESCRIPTION
### **PR Type**
Bug fix, Configuration

___

### **PR Description**
- Fixed the `serverAccessLogsBucket` naming rule to include `resourcePrefix`.

- Updated `cdk-nag` dependency from `2.35.40` to `2.35.41`.

- Bumped package version from `0.1.4` to `0.1.5`.
