### PR TITLE
Develop

### DIFF
--- a/lib/aws-s3-stack.ts
+++ b/lib/aws-s3-stack.ts
@@ -36,7 +36,7 @@ export class AwsS3Stack extends cdk.Stack {
 
       // export deployment bucket name
       new cdk.CfnOutput(this, `${props.resourcePrefix}-${s3BucketName}-deployment-bucket-name-Export`, {
-        value: s3BucketName,
+        value: `${props.resourcePrefix}-${s3BucketName}`,
         exportName: `${props.deployEnvironment}-${props.deployRegion}-${s3BucketName}-deployment-bucket-name-Export`,
         description: 'The name of the deployment bucket.',
       });

--- a/lib/aws-s3-stack.ts
+++ b/lib/aws-s3-stack.ts
@@ -26,18 +26,17 @@ export class AwsS3Stack extends cdk.Stack {
     });
 
     for (const s3BucketName of props.s3BucketNames) {
-      const deploymentBucketName = `${props.resourcePrefix}-${s3BucketName}`;
       new AwsS3BucketsNestedStack(this, `${s3BucketName}-AwsS3BucketsNestedStack`, {
         ...props,
-        s3BucketName: deploymentBucketName,
+        s3BucketName: s3BucketName,
         kmsKeyArn: kmsKey.keyArn,
         removalPolicy: removalPolicy,
-        description: `${props.resourcePrefix}-${deploymentBucketName}-AwsS3BucketsNestedStack`,
+        description: `${props.resourcePrefix}-${s3BucketName}-AwsS3BucketsNestedStack`,
       });
 
       // export deployment bucket name
       new cdk.CfnOutput(this, `${props.resourcePrefix}-${s3BucketName}-deployment-bucket-name-Export`, {
-        value: deploymentBucketName,
+        value: s3BucketName,
         exportName: `${props.deployEnvironment}-${props.deployRegion}-${s3BucketName}-deployment-bucket-name-Export`,
         description: 'The name of the deployment bucket.',
       });

--- a/lib/constructs/aws-s3-buckets-nested-stack.ts
+++ b/lib/constructs/aws-s3-buckets-nested-stack.ts
@@ -13,7 +13,7 @@ export class AwsS3BucketsNestedStack extends NestedStack {
 
     // define an S3 bucket
     const s3Bucket = new s3.Bucket(this, `${props.resourcePrefix}-${props.s3BucketName}`, {
-        bucketName: `${props.s3BucketName}`,
+        bucketName: `${props.resourcePrefix}-${props.s3BucketName}`,
         encryption: s3.BucketEncryption.KMS,
         encryptionKey: existingKmsKey,
         blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
@@ -21,7 +21,7 @@ export class AwsS3BucketsNestedStack extends NestedStack {
         removalPolicy: props.removalPolicy,
         autoDeleteObjects: props.removalPolicy === cdk.RemovalPolicy.DESTROY,
         accessControl: s3.BucketAccessControl.BUCKET_OWNER_FULL_CONTROL,
-        versioned: true, // Enable versioning
+        versioned: true,
         lifecycleRules: [
             {
                 transitions: [


### PR DESCRIPTION
### **PR Type**
Refactoring, Enhancement

___

### **PR Description**
- Simplified `s3BucketName` naming rule by removing redundant prefix concatenation.

- Fixed export bucket name to include `resourcePrefix` consistently.

- Updated `AwsS3BucketsNestedStack` to use `resourcePrefix` in `bucketName`.

- Ensured consistent naming across S3 bucket exports and descriptions.
