### PR TITLE
Update resources naming conventions for multiple regions deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2025-03-10][PR#29](https://github.com/OpenWorkspace-o1/aws-ow-s3-buckets/pull/29)
+
+### Changed
+- Updated resource naming conventions to include `deployRegion` for multi-region deployments, affecting KMS keys, S3 buckets, and log buckets.
+- Modified export names for KMS keys, S3 buckets, and log buckets to include region for better regional identification.
+
 ## [2025-03-10][PR#25](https://github.com/OpenWorkspace-o1/aws-ow-s3-buckets/pull/25)
 
 ### Fixed

--- a/lib/aws-s3-stack.ts
+++ b/lib/aws-s3-stack.ts
@@ -17,12 +17,12 @@ export class AwsS3Stack extends cdk.Stack {
 
     const removalPolicy = props.deployEnvironment === 'production' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY;
 
-    const kmsKey = new kms.Key(this, `${props.resourcePrefix}-s3-buckets-kms-key`, {
+    const kmsKey = new kms.Key(this, `${props.resourcePrefix}-${props.deployRegion}-s3-buckets-kms-key`, {
       enabled: true,
       enableKeyRotation: true,
       rotationPeriod: cdk.Duration.days(90),
       removalPolicy: removalPolicy,
-      description: `${props.resourcePrefix}-s3-buckets-kms-key`,
+      description: `${props.resourcePrefix}-${props.deployRegion}-s3-buckets-kms-key`,
     });
 
     for (const s3BucketName of props.s3BucketNames) {
@@ -36,21 +36,21 @@ export class AwsS3Stack extends cdk.Stack {
 
       // export deployment bucket name
       new cdk.CfnOutput(this, `${props.resourcePrefix}-${s3BucketName}-deployment-bucket-name-Export`, {
-        value: `${props.resourcePrefix}-${s3BucketName}`,
+        value: `${props.resourcePrefix}-${props.deployRegion}-${s3BucketName}`,
         exportName: `${props.deployEnvironment}-${props.deployRegion}-${s3BucketName}-deployment-bucket-name-Export`,
         description: 'The name of the deployment bucket.',
       });
     }
 
     // export kmsKey ARN
-    new cdk.CfnOutput(this, `${props.resourcePrefix}-s3-buckets-kms-key-Arn-Export`, {
+    new cdk.CfnOutput(this, `${props.resourcePrefix}-${props.deployRegion}-s3-buckets-kms-key-Arn-Export`, {
       value: kmsKey.keyArn,
       exportName: `${props.deployEnvironment}-${props.deployRegion}-s3-buckets-kms-key-Arn-Export`,
       description: 'The ARN of the KMS key.',
     });
 
     // export kmsKey ID
-    new cdk.CfnOutput(this, `${props.resourcePrefix}-s3-buckets-kms-key-Id-Export`, {
+    new cdk.CfnOutput(this, `${props.resourcePrefix}-${props.deployRegion}-s3-buckets-kms-key-Id-Export`, {
       value: kmsKey.keyId,
       exportName: `${props.deployEnvironment}-${props.deployRegion}-s3-buckets-kms-key-Id-Export`,
       description: 'The ID of the KMS key.',

--- a/lib/constructs/aws-s3-buckets-nested-stack.ts
+++ b/lib/constructs/aws-s3-buckets-nested-stack.ts
@@ -12,8 +12,8 @@ export class AwsS3BucketsNestedStack extends NestedStack {
     const existingKmsKey = kms.Key.fromKeyArn(this, `${props.resourcePrefix}-${props.s3BucketName}-kms-key`, props.kmsKeyArn);
 
     // define an S3 bucket
-    const s3Bucket = new s3.Bucket(this, `${props.resourcePrefix}-${props.s3BucketName}`, {
-        bucketName: `${props.resourcePrefix}-${props.s3BucketName}`,
+    const s3Bucket = new s3.Bucket(this, `${props.resourcePrefix}-${props.deployRegion}-${props.s3BucketName}`, {
+        bucketName: `${props.resourcePrefix}-${props.deployRegion}-${props.s3BucketName}`,
         encryption: s3.BucketEncryption.KMS,
         encryptionKey: existingKmsKey,
         blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
@@ -43,8 +43,8 @@ export class AwsS3BucketsNestedStack extends NestedStack {
                 deepArchiveAccessTierTime: cdk.Duration.days(180),
             },
         ],
-        serverAccessLogsBucket: new s3.Bucket(this, `${props.resourcePrefix}-${props.s3BucketName}-logs`, {
-            bucketName: `${props.resourcePrefix}-${props.s3BucketName}-logs`,
+        serverAccessLogsBucket: new s3.Bucket(this, `${props.resourcePrefix}-${props.deployRegion}-${props.s3BucketName}-logs`, {
+            bucketName: `${props.resourcePrefix}-${props.deployRegion}-${props.s3BucketName}-logs`,
             encryption: s3.BucketEncryption.S3_MANAGED,
             blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
             publicReadAccess: false,
@@ -53,18 +53,18 @@ export class AwsS3BucketsNestedStack extends NestedStack {
             enforceSSL: true,
         }),
         enforceSSL: true,
-        serverAccessLogsPrefix: `${props.resourcePrefix}-${props.s3BucketName}-logs/`
+        serverAccessLogsPrefix: `${props.resourcePrefix}-${props.deployRegion}-${props.s3BucketName}-logs/`
     });
 
     // export s3Bucket name
-    new cdk.CfnOutput(this, `${props.resourcePrefix}-${props.s3BucketName}-Export`, {
+    new cdk.CfnOutput(this, `${props.resourcePrefix}-${props.deployRegion}-${props.s3BucketName}-Export`, {
         value: s3Bucket.bucketName,
         exportName: `${props.deployEnvironment}-${props.deployRegion}-${props.s3BucketName}-Export`,
         description: 'The name of the S3 bucket.',
     });
 
     // export s3Bucket ARN
-    new cdk.CfnOutput(this, `${props.resourcePrefix}-${props.s3BucketName}-Arn-Export`, {
+    new cdk.CfnOutput(this, `${props.resourcePrefix}-${props.deployRegion}-${props.s3BucketName}-Arn-Export`, {
         value: s3Bucket.bucketArn,
         exportName: `${props.deployEnvironment}-${props.deployRegion}-${props.s3BucketName}-Arn-Export`,
         description: 'The ARN of the S3 bucket.',


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration

___

### **PR Description**
- Updated resource naming conventions to include `deployRegion` for multi-region deployments.
  - Modified KMS key, S3 bucket, and log bucket names to include region.
  - Updated export names for KMS key, S3 bucket, and log bucket to include region.

- Ensured consistent naming across all resources for better regional identification.
